### PR TITLE
1 store datasets as safetensors inside an lmdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 *pycache*
 *DS_Store*
 /untracked-files
-__init__.py
-metadata_exploration.py
+/dataset_conversion

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /venv
 *pycache*
 *DS_Store*
+/untracked-files
+__init__.py
+metadata_exploration.py

--- a/convert_BEN.py
+++ b/convert_BEN.py
@@ -1,5 +1,10 @@
-# imports
-
+import os
+import pandas as pd
+import numpy as np
+from PIL import Image
+import lmdb
+import tqdm
+from safetensors.numpy import save
 
 # expected resolutions for the BigEarthNet dataset
 expected_resolutions = {
@@ -18,26 +23,128 @@ expected_resolutions = {
 }
 
 
+def convert_tif_file_to_numpy_array(tif_file_path):
+    # Convert a .tif file to a numpy array
+    with Image.open(tif_file_path) as img:
+        return np.array(img)
+
+
+def create_band_dictionary():
+    # Create a dict with keys from the expected_resolutions, initialized as empty arrays
+    band_dict = {band: np.array([]) for band in expected_resolutions.keys()}
+    assert len(band_dict) == 12, "We expect each patch to have 12 bands"
+    return band_dict
+
+
+def convert_ben_dataset_to_lmdb(ben_dataset_path, lmdb_dir):
+    """
+    Convert the BEN dataset to an LMDB database of safetensor patches.
+
+    :param ben_dataset_path: Path to the BEN dataset.
+    :param lmdb_dir: Directory where the LMDB database will be stored.
+    """
+    # Ensure the LMDB directory exists
+    if not os.path.exists(lmdb_dir):
+        os.makedirs(lmdb_dir, exist_ok=True)
+
+    # First, collect all patch directories that contain at least one .tif file
+    patch_dirs = []
+    for root, dirs, files in os.walk(ben_dataset_path):
+        if any(f.endswith('.tif') for f in files):
+            patch_dirs.append(root)
+
+    total_folders = len(patch_dirs)
+
+    # Open the LMDB environment with a specified map size
+    with lmdb.open(lmdb_dir, map_size=int(1e12)) as env:
+
+        with env.begin(write=True) as txn:
+
+            # Iterate over all patch directories with tqdm showing progress
+            for root in tqdm.tqdm(patch_dirs, total=total_folders, desc="Processing folders", unit="folder"):
+                patch_path = root
+                band_dict = create_band_dictionary()
+
+                tif_files = [f for f in os.listdir(
+                    patch_path) if f.endswith('.tif')]
+
+                for tif_file in tif_files:
+                    # Extract band name (e.g., "B02") from filename
+                    band_name = tif_file.split('_')[-1].replace('.tif', '')
+                    arr = convert_tif_file_to_numpy_array(
+                        os.path.join(patch_path, tif_file))
+
+                    # Assert that the band's resolution matches the expected resolution
+                    assert band_name in expected_resolutions, f"Unexpected band name: {
+                        band_name}"
+                    expected_res = expected_resolutions[band_name]
+                    assert arr.shape[0] == expected_res, (
+                        f"Resolution mismatch for band {band_name}: expected {
+                            expected_res}, got {arr.shape[0]}"
+                    )
+
+                    band_dict[band_name] = arr
+
+                # Convert the band dictionary to safetensor bytes
+                tensor_bytes = save(band_dict)
+
+                # Use the folder name as the key
+                folder_name = os.path.basename(patch_path)
+                txn.put(folder_name.encode(), tensor_bytes)
+
+
+def count_samples_in_lmdb(lmdb_path: str) -> int:
+    """Count the number of samples in the LMDB database."""
+    with lmdb.open(lmdb_path, readonly=True) as env:
+        with env.begin() as txn:
+            return txn.stat()['entries']
+
+
 def main(input_data_path: str, output_lmdb_path: str, output_parquet_path: str):
     """
     Convert the BigEarthNet dataset to lmdb and parquet format.
 
     :param input_data_path: path to the source BigEarthNet dataset (root of the tar file)
-    :param output_lmdb_path: path to the destination BigEarthNet lmdb file
+    :param output_lmdb_path: path to the destination BigEarthNet lmdb directory
     :param output_parquet_path: path to the destination BigEarthNet parquet file
     :return: None
     """
 
-    # TODO: Read the tif files and write them to the lmdb file.
-    # TODO: Write the metadata to a parquet file.
-    # TODO: Print the number of samples in the dataset and the number of samples in each split.
+    # Convert the dataset to LMDB
+    convert_ben_dataset_to_lmdb(input_data_path, output_lmdb_path)
 
-    num_keys = ...
-    num_train_samples = ...
-    num_validation_samples = ...
-    num_test_samples = ...
+    # Count total samples
+    num_keys = count_samples_in_lmdb(output_lmdb_path)
+
+    # Read metadata
+    metadata_df = pd.read_parquet(
+        'untracked-files/BigEarthNet-Lithuania-Summer/lithuania_summer.parquet')
+
+    # Store as parquet file in output_parquet_path
+    metadata_df.to_parquet(output_parquet_path)
+
+    # Count the number of samples in the dataset and the number of samples in each split.
+    num_train_samples = len(metadata_df[metadata_df['split'] == 'train'])
+    num_validation_samples = len(
+        metadata_df[metadata_df['split'] == 'validation'])
+    num_test_samples = len(metadata_df[metadata_df['split'] == 'test'])
+
+    assert num_keys == num_train_samples + num_validation_samples + num_test_samples, (
+        f"The number of keys in the LMDB database is {
+            num_keys} which is not equal to "
+        f"the number of samples in the dataset {
+            num_train_samples + num_validation_samples + num_test_samples}"
+    )
 
     print(f"#samples: {num_keys}")
     print(f"#samples_train: {num_train_samples}")
     print(f"#samples_validation: {num_validation_samples}")
     print(f"#samples_test: {num_test_samples}")
+
+
+if __name__ == "__main__":
+    main(
+        input_data_path='untracked-files/BigEarthNet-Lithuania-Summer',
+        output_lmdb_path='untracked-files/datasets',
+        output_parquet_path='untracked-files/datasets/metadata/metadata_ben.parquet'
+    )

--- a/convert_EuroSAT.py
+++ b/convert_EuroSAT.py
@@ -1,4 +1,109 @@
-# imports
+import rasterio
+from safetensors.numpy import save
+import lmdb
+import os
+from pathlib import Path
+import pandas as pd
+import tqdm
+BAND_DICT = {
+    'B01': None,
+    'B02': None,
+    'B03': None,
+    'B04': None,
+    'B05': None,
+    'B06': None,
+    'B07': None,
+    'B08': None,
+    'B09': None,
+    'B10': None,
+    'B11': None,
+    'B12': None,
+    'B8A': None
+}
+
+
+def get_band_safetensor_from_tif(tif_path):
+    with rasterio.open(tif_path) as src:
+        tmp_band_dict = {}
+        for i in range(1, src.count + 1):
+            content = src.read(i)
+            tmp_band_dict[f'band_{i}'] = content
+        st = save(tmp_band_dict)  # saves to a safetensors buffer
+        return st
+
+
+def convert_eurosat_dataset_to_lmdb(eurosat_dataset_path, lmdb_dir):
+    """
+    Convert the EuroSAT dataset to an LMDB database of safetensors.
+    """
+    lmdb_path = Path(lmdb_dir)
+    lmdb_path.mkdir(parents=True, exist_ok=True)
+
+    base_path = Path(eurosat_dataset_path)
+    label_folders = [f for f in base_path.iterdir() if f.is_dir()]
+
+    with lmdb.open(str(lmdb_path), map_size=int(1e12)) as env:
+        with env.begin(write=True) as txn:
+            for label_folder in tqdm.tqdm(label_folders, desc="Processing label folders", unit="folder"):
+                # We assume only TIF files; let's assert this
+                tif_files = list(label_folder.iterdir())
+                for f in tif_files:
+                    assert f.suffix.lower(
+                    ) == '.tif', f"Non-TIF file found: {f}"
+
+                # Store each tif file in LMDB
+                for tif_file in tqdm.tqdm(tif_files, desc=f"Storing TIFFs for {label_folder.name}", unit="file", leave=False):
+                    st = get_band_safetensor_from_tif(tif_file)
+                    txn.put(tif_file.name.encode(), st)
+
+
+def gather_metadata(input_data_path: str) -> pd.DataFrame:
+    """
+    Gather metadata for the EuroSAT dataset.
+    For each class folder, assign 70% train, 15% validation, 15% test splits based on file index.
+    """
+    base_path = Path(input_data_path)
+    label_folders = [f for f in base_path.iterdir() if f.is_dir()]
+
+    all_entries = []
+    for label_folder in tqdm.tqdm(label_folders, desc="Gathering metadata", unit="folder"):
+        label = label_folder.name
+
+        # Collect all tif files and assert no other files are present
+        tif_files = list(label_folder.iterdir())
+        for f in tif_files:
+            assert f.suffix.lower() == '.tif', f"Non-TIF file found: {f}"
+
+        n = len(tif_files)
+        n_train = int(n * 0.7)
+        n_val = int(n * 0.15)
+
+        for i, tif_path in enumerate(tif_files):
+            stem = tif_path.stem
+            current_label = stem.split("_")[0]
+            # Determine split based on index i
+            if i < n_train:
+                split = "train"
+            elif i < n_train + n_val:
+                split = "validation"
+            else:
+                split = "test"
+
+            all_entries.append({
+                'id': tif_path.name,    # store filename as id
+                'label': current_label,
+                'split': split
+            })
+
+    df = pd.DataFrame(all_entries)
+    return df
+
+
+def store_metadata(df: pd.DataFrame, output_parquet_path: str):
+    """
+    Store metadata DataFrame as a parquet file.
+    """
+    df.to_parquet(output_parquet_path, index=False)
 
 
 def main(input_data_path: str, output_lmdb_path: str, output_parquet_path: str):
@@ -10,21 +115,29 @@ def main(input_data_path: str, output_lmdb_path: str, output_parquet_path: str):
     :param output_parquet_path: path to the destination EuroSAT parquet file
     :return: None
     """
+    # Gather metadata
+    metadata = gather_metadata(input_data_path)
 
-    # TODO: Read the tif files and write them to the lmdb file.
-    # TODO: Create a split for the dataset.
-    #       For every class the first 70% of the samples are used for training, the next 15% for validation and the last
-    #       15% for testing. The samples should be ordered by the number in their filename number, 1,2,3,...,n - be
-    #       aware, that the order of 1,2,3,...,10,...,n is not the same as when you sort them as strings.
-    # TODO: Write the metadata to a parquet file.
-    # TODO: Print the number of samples in the dataset and the number of samples in each split.
+    # Store metadata
+    store_metadata(metadata, output_parquet_path)
 
-    num_keys = ...
-    num_train_samples = ...
-    num_validation_samples = ...
-    num_test_samples = ...
+    # Convert data to LMDB
+    convert_eurosat_dataset_to_lmdb(input_data_path, output_lmdb_path)
+
+    # Print the number of samples in the dataset and the number of samples in each split.
+    num_keys = len(metadata)
+    num_train_samples = len(metadata[metadata['split'] == 'train'])
+    num_validation_samples = len(metadata[metadata['split'] == 'validation'])
+    num_test_samples = len(metadata[metadata['split'] == 'test'])
 
     print(f"#samples: {num_keys}")
     print(f"#samples_train: {num_train_samples}")
     print(f"#samples_validation: {num_validation_samples}")
     print(f"#samples_test: {num_test_samples}")
+
+
+if __name__ == "__main__":
+    input_data_path = 'untracked-files/EuroSAT_MS'
+    output_lmdb_path = 'untracked-files/datasets/EuroSAT'
+    output_parquet_path = 'untracked-files/datasets/EuroSAT/metadata.parquet'
+    main(input_data_path, output_lmdb_path, output_parquet_path)


### PR DESCRIPTION
Finished the first task. Adapted convert_BEN.py and convert_EuroSAY.py, so that they create an lmdb for each dataset as well as their metadata as a parquet file. 

So far, metadata for both datasets consists of three columns:
1. id
2. label
3. split

A metadata parquet file for BEN already exists as `BigEarthNet-Lithuania-Summer/lithuania_summer.parquet`. The file includes the aformentioned columns + a country column. The latter is removed because country = lithuania for the entire dataset. 

For EuroSAT, we had to create a metadata.parquet file ourselves. The id corrseponds to the entire filename, e.g. AnnualCrop_1.tif. The label consists of the stem of the filename, e.g. AnnualCrop. The split is determined by computing the relative number of samples that belong to the corresponding split. 

The conversion to LMDB database was pretty straight forward, but since I don't have much experience, there might be an issue here and there.

There will be a couple of things we might have to adjust depending on the following steps of the training pipeline:
- Filestructure (are they stored at the right place)
- id and label characteristics (are the ids and labels stored in a way that makes sense for pre-processing?)


